### PR TITLE
refactor: Uses new enum kind for aarch64 instruction

### DIFF
--- a/src/Domain/Compiler/Instruction/Assembly/Aarch/Aarch64Writer.cpp
+++ b/src/Domain/Compiler/Instruction/Assembly/Aarch/Aarch64Writer.cpp
@@ -176,6 +176,7 @@ namespace elet::domain::compiler::instruction::output
         bw->writeDoubleWordInFunction(Aarch64Instruction::Ret | Rn(Aarch64Register::lr), function);
     }
 
+
     uint32_t
     Aarch64Writer::Rm(uint8_t reg) const
     {

--- a/src/Domain/Compiler/TestHarness/Aarch/Aarch64Instructions.cpp
+++ b/src/Domain/Compiler/TestHarness/Aarch/Aarch64Instructions.cpp
@@ -2,30 +2,30 @@
 
 namespace elet::domain::compiler::test::aarch
 {
-    Instruction::Instruction(Aarch64Instruction kind):
+    Instruction::Instruction(InstructionKind kind):
         kind(kind),
         is64Bit(false)
     { }
 
 
-    Instruction::Instruction(Aarch64Instruction kind, bool is64Bit):
+    Instruction::Instruction(InstructionKind kind, bool is64Bit):
         kind(kind),
         is64Bit(is64Bit)
     { }
 
 
     UdfInstruction::UdfInstruction(int16_t imm16):
-        Instruction(Aarch64Instruction::Udf),
+        Instruction(InstructionKind::Udf),
         imm16(imm16)
     { }
 
 
     NopInstruction::NopInstruction():
-        Instruction(Aarch64Instruction::Nop)
+        Instruction(InstructionKind::Nop)
     { }
 
 
-    AddSubImmediateInstruction::AddSubImmediateInstruction(Aarch64Instruction kind, Register Rd, Register Rn, uint16_t imm12, bool is64Bit):
+    AddSubImmediateInstruction::AddSubImmediateInstruction(InstructionKind kind, Register Rd, Register Rn, uint16_t imm12, bool is64Bit):
         Instruction(kind, is64Bit),
         Rd(Rd),
         Rn(Rn),
@@ -33,7 +33,7 @@ namespace elet::domain::compiler::test::aarch
     { }
 
 
-    LdrStrImmediateUnsignedOffsetInstruction::LdrStrImmediateUnsignedOffsetInstruction(Aarch64Instruction kind, Register Rt, Register Rn, uint16_t imm12, bool is64Bit):
+    LdrStrImmediateUnsignedOffsetInstruction::LdrStrImmediateUnsignedOffsetInstruction(InstructionKind kind, Register Rt, Register Rn, uint16_t imm12, bool is64Bit):
         Instruction(kind, is64Bit),
         Rt(Rt),
         Rn(Rn),
@@ -41,33 +41,34 @@ namespace elet::domain::compiler::test::aarch
     { }
 
 
-    LdrbStrbImmediateUnsignedOffsetInstruction::LdrbStrbImmediateUnsignedOffsetInstruction(Aarch64Instruction kind, Register Rt, Register Rn, uint16_t imm12):
+    LdrbStrbImmediateUnsignedOffsetInstruction::LdrbStrbImmediateUnsignedOffsetInstruction(InstructionKind kind, Register Rt, Register Rn, uint16_t imm12):
         LdrStrImmediateUnsignedOffsetInstruction(kind, Rt, Rn, imm12, false)
     { }
 
 
-    LdrhStrhImmediateUnsignedOffsetInstruction::LdrhStrhImmediateUnsignedOffsetInstruction(Aarch64Instruction kind, Register Rt, Register Rn, uint16_t imm12):
+    LdrhStrhImmediateUnsignedOffsetInstruction::LdrhStrhImmediateUnsignedOffsetInstruction(InstructionKind kind, Register Rt, Register Rn, uint16_t imm12):
         LdrbStrbImmediateUnsignedOffsetInstruction(kind, Rt, Rn, imm12)
     { }
 
 
     LdrsbImmediateUnsignedOffsetInstruction::LdrsbImmediateUnsignedOffsetInstruction(Register Rt, Register Rn, uint16_t imm12):
-        LdrbStrbImmediateUnsignedOffsetInstruction(Aarch64Instruction::LdrsbImmediateUnsignedOffset, Rt, Rn, imm12)
+        LdrbStrbImmediateUnsignedOffsetInstruction(InstructionKind::LdrsbImmediateUnsignedOffset, Rt, Rn, imm12)
     { }
 
 
     LdrshImmediateUnsignedOffsetInstruction::LdrshImmediateUnsignedOffsetInstruction(Register Rt, Register Rn, uint16_t imm12):
-        LdrbStrbImmediateUnsignedOffsetInstruction(Aarch64Instruction::LdrshImmediateUnsignedOffset, Rt, Rn, imm12)
+        LdrbStrbImmediateUnsignedOffsetInstruction(InstructionKind::LdrshImmediateUnsignedOffset, Rt, Rn, imm12)
     { }
 
+
     LdrInstruction::LdrInstruction(Register Rt, int32_t imm19, bool is64Bit):
-        Instruction(Aarch64Instruction::Ldr32, is64Bit),
+        Instruction(InstructionKind::Ldr, is64Bit),
         Rt(Rt),
         imm19(imm19)
     { }
 
 
-    LoadStorePairInstruction::LoadStorePairInstruction(Aarch64Instruction kind, Register Rt, Register Rt2, Register Rn, int8_t imm7, AddressMode addressMode, bool is64Bit):
+    LoadStorePairInstruction::LoadStorePairInstruction(InstructionKind kind, Register Rt, Register Rt2, Register Rn, int8_t imm7, AddressMode addressMode, bool is64Bit):
         Instruction(kind, is64Bit),
         Rt(Rt),
         Rt2(Rt2),
@@ -75,15 +76,15 @@ namespace elet::domain::compiler::test::aarch
         imm7(imm7),
         addressMode(addressMode)
     {
-        assert(kind == Aarch64Instruction::StpOffset64 ||
-        kind == Aarch64Instruction::LdpOffset64 ||
-        kind == Aarch64Instruction::LdpPostIndex64 ||
-        kind == Aarch64Instruction::StpPreIndex64 && "Unknown kind");
+        assert(kind == InstructionKind::StpOffset ||
+            kind == InstructionKind::LdpOffset ||
+            kind == InstructionKind::LdpPostIndex ||
+            kind == InstructionKind::StpPreIndex && "Unknown kind");
     }
 
 
     AndImmediateInstruction::AndImmediateInstruction(uint64_t value, Register Rn, Register Rd, bool is64Bit):
-        Instruction(Aarch64Instruction::AndImmediate, is64Bit),
+        Instruction(InstructionKind::AndImmediate, is64Bit),
         value(value),
         Rn(Rn),
         Rd(Rd)
@@ -91,38 +92,38 @@ namespace elet::domain::compiler::test::aarch
 
 
     BInstruction::BInstruction(int32_t imm26):
-        Instruction(Aarch64Instruction::B),
+        Instruction(InstructionKind::B),
         imm26(imm26)
     { }
 
 
     BrInstruction::BrInstruction(Register Rn):
-        Instruction(Aarch64Instruction::Br),
+        Instruction(InstructionKind::Br),
         Rn(Rn)
     { }
 
 
     BlInstruction::BlInstruction(int32_t imm26):
-        Instruction(Aarch64Instruction::Bl),
+        Instruction(InstructionKind::Bl),
         withLink(true),
         imm26(imm26)
     { }
 
 
     RetInstruction::RetInstruction(Register Rn):
-        Instruction(Aarch64Instruction::Ret),
+        Instruction(InstructionKind::Ret),
         Rn(Rn)
     { }
 
 
     OrrImmediateInstruction::OrrImmediateInstruction(Register Rd, Register Rn, uint64_t value, bool is64Bit):
-        Instruction(Aarch64Instruction::OrrImmediate, is64Bit),
+        Instruction(InstructionKind::OrrImmediate, is64Bit),
         Rd(Rd),
         Rn(Rn),
         value(value)
     { }
 
-    MovInstruction::MovInstruction(Aarch64Instruction kind, Register rd, uint16_t imm16, Hw hw, bool is64Bit):
+    MovInstruction::MovInstruction(InstructionKind kind, Register rd, uint16_t imm16, Hw hw, bool is64Bit):
         Instruction(kind, is64Bit),
         Rd(rd),
         imm16(imm16),
@@ -131,14 +132,14 @@ namespace elet::domain::compiler::test::aarch
 
 
     MovzInstruction::MovzInstruction(Register Rd, uint16_t imm16, Hw hw, bool is64Bit):
-        MovInstruction(Aarch64Instruction::Movz, Rd, imm16, hw, is64Bit)
+        MovInstruction(InstructionKind::Movz, Rd, imm16, hw, is64Bit)
     {
         immediateValue = static_cast<uint64_t>(imm16) << (static_cast<uint64_t>(hw) * 16);
     }
 
 
     MovnInstruction::MovnInstruction(Register rd, uint16_t imm16, Hw hw, bool is64Bit):
-        MovInstruction(Aarch64Instruction::Movn, rd, imm16, hw, is64Bit)
+        MovInstruction(InstructionKind::Movn, rd, imm16, hw, is64Bit)
     {
         uint16_t s = ~imm16;
         int64_t rimm16 = static_cast<int64_t>(s);
@@ -158,7 +159,7 @@ namespace elet::domain::compiler::test::aarch
 
 
     MovkInstruction::MovkInstruction(Register Rd, uint16_t imm16, Hw hw, bool is64Bit):
-        MovInstruction(Aarch64Instruction::Movk, Rd, imm16, hw, is64Bit),
+        MovInstruction(InstructionKind::Movk, Rd, imm16, hw, is64Bit),
         immediateValue(imm16)
     {
 
@@ -166,20 +167,20 @@ namespace elet::domain::compiler::test::aarch
 
 
     AdrpInstruction::AdrpInstruction(Register rd, uint32_t immhilo):
-        Instruction(Aarch64Instruction::Adrp),
+        Instruction(InstructionKind::Adrp),
         rd(rd),
         immhilo(immhilo)
     { }
 
 
     AdrInstruction::AdrInstruction(Register rd, uint32_t immhilo):
-        Instruction(Aarch64Instruction::Adr),
+        Instruction(InstructionKind::Adr),
         rd(rd),
         immhilo(immhilo)
     { }
 
 
-    ShiftedRegisterInstruction::ShiftedRegisterInstruction(Aarch64Instruction instruction, Register Rd, Register Rn, Register Rm, uint8_t shift, uint8_t imm6, bool is64Bit):
+    ShiftedRegisterInstruction::ShiftedRegisterInstruction(InstructionKind instruction, Register Rd, Register Rn, Register Rm, uint8_t shift, uint8_t imm6, bool is64Bit):
         Instruction(instruction, is64Bit),
         Rd(Rd),
         Rn(Rn),
@@ -190,16 +191,16 @@ namespace elet::domain::compiler::test::aarch
 
 
     AddShiftedRegisterInstruction::AddShiftedRegisterInstruction(Register Rd, Register Rn, Register Rm, uint8_t shift, uint8_t imm6, bool is64Bit):
-        ShiftedRegisterInstruction(Aarch64Instruction::AddShiftedRegister, Rd, Rn, Rm, shift, imm6, is64Bit)
+        ShiftedRegisterInstruction(InstructionKind::AddShiftedRegister, Rd, Rn, Rm, shift, imm6, is64Bit)
     { }
 
 
     SubShiftedRegisterInstruction::SubShiftedRegisterInstruction(Register Rd, Register Rn, Register Rm, uint8_t shift, uint8_t imm6, bool is64Bit):
-        ShiftedRegisterInstruction(Aarch64Instruction::SubShiftedRegister, Rd, Rn, Rm, shift, imm6, is64Bit)
+        ShiftedRegisterInstruction(InstructionKind::SubShiftedRegister, Rd, Rn, Rm, shift, imm6, is64Bit)
     { }
 
 
-    MaddSubInstruction::MaddSubInstruction(Aarch64Instruction kind, Register Rm, Register Ra, Register Rn, Register Rd, bool is64Bit):
+    MaddSubInstruction::MaddSubInstruction(InstructionKind kind, Register Rm, Register Ra, Register Rn, Register Rd, bool is64Bit):
         Instruction(kind, is64Bit),
         Rm(Rm),
         Ra(Ra),
@@ -208,7 +209,7 @@ namespace elet::domain::compiler::test::aarch
     { }
 
 
-    DivInstruction::DivInstruction(Aarch64Instruction kind, Register Rm, Register Rn, Register Rd, bool is64Bit):
+    DivInstruction::DivInstruction(InstructionKind kind, Register Rm, Register Rn, Register Rd, bool is64Bit):
         Instruction(kind, is64Bit),
         Rm(Rm),
         Rn(Rn),
@@ -216,7 +217,7 @@ namespace elet::domain::compiler::test::aarch
     { }
 
 
-    SxtbSxtbhInstruction::SxtbSxtbhInstruction(Aarch64Instruction kind, Register Rd, Register Rn):
+    SxtbSxtbhInstruction::SxtbSxtbhInstruction(InstructionKind kind, Register Rd, Register Rn):
         Instruction(kind),
         Rd(Rd),
         Rn(Rn)
@@ -224,12 +225,12 @@ namespace elet::domain::compiler::test::aarch
 
 
     SxtbInstruction::SxtbInstruction(Register Rd, Register Rn):
-        SxtbSxtbhInstruction(Aarch64Instruction::Sxtb, Rd, Rn)
+        SxtbSxtbhInstruction(InstructionKind::Sxtb, Rd, Rn)
     { }
 
 
     SxthInstruction::SxthInstruction(Register Rd, Register Rn):
-        SxtbSxtbhInstruction(Aarch64Instruction::Sxth, Rd, Rn)
+        SxtbSxtbhInstruction(InstructionKind::Sxth, Rd, Rn)
     { }
 
 

--- a/src/Domain/Compiler/TestHarness/Aarch/Aarch64Instructions.h
+++ b/src/Domain/Compiler/TestHarness/Aarch/Aarch64Instructions.h
@@ -32,15 +32,50 @@ namespace elet::domain::compiler::test::aarch
     };
 
 
-    // TODO: Used for new rewrite.
     enum class InstructionKind
     {
         Udf,
+        Nop,
+        LdrsbImmediateUnsignedOffset,
+        LdrshImmediateUnsignedOffset,
+        Ldr,
+        StpOffset,
+        LdpOffset,
+        LdpPostIndex,
+        StpPreIndex,
+        StrImmediateUnsignedOffset,
+        LdrImmediateUnsignedOffset,
+        LdrbImmediateUnsignedOffset,
+        StrbImmediateUnsignedOffset,
+        LdrhImmediateUnsignedOffset,
+        StrhImmediateUnsignedOffset,
+        AndImmediate,
+        B,
+        Br,
+        Bl,
+        Ret,
+        OrrImmediate,
+        Movz,
+        Movn,
+        Movk,
+        Adrp,
+        Adr,
+        Sdiv,
+        Udiv,
+        AddImmediate,
+        SubImmediate,
+        AddShiftedRegister,
+        SubShiftedRegister,
+        Madd,
+        Msub,
+        Sxtb,
+        Sxth
     };
+
 
     struct Instruction
     {
-        Aarch64Instruction
+        InstructionKind
         kind;
 
         bool
@@ -49,11 +84,10 @@ namespace elet::domain::compiler::test::aarch
         List<uint8_t>
         bytes;
 
-        Instruction(Aarch64Instruction kind);
+        Instruction(InstructionKind kind);
 
-        Instruction(Aarch64Instruction kind, bool is64Bit);
+        Instruction(InstructionKind kind, bool is64Bit);
     };
-
 
 
     struct UdfInstruction : Instruction
@@ -83,7 +117,7 @@ namespace elet::domain::compiler::test::aarch
         imm12;
 
         AddSubImmediateInstruction(
-            Aarch64Instruction kind,
+            InstructionKind kind,
             Register Rd,
             Register Rn,
             uint16_t imm12, bool is64Bit);
@@ -124,7 +158,7 @@ namespace elet::domain::compiler::test::aarch
         imm12;
 
         LdrStrImmediateUnsignedOffsetInstruction(
-            Aarch64Instruction kind,
+            InstructionKind kind,
             Register Rt,
             Register Rn,
             uint16_t imm12,
@@ -145,13 +179,13 @@ namespace elet::domain::compiler::test::aarch
 
     struct LdrbStrbImmediateUnsignedOffsetInstruction : LdrStrImmediateUnsignedOffsetInstruction
     {
-        LdrbStrbImmediateUnsignedOffsetInstruction(Aarch64Instruction kind, Register Rt, Register Rn, uint16_t imm12);
+        LdrbStrbImmediateUnsignedOffsetInstruction(InstructionKind kind, Register Rt, Register Rn, uint16_t imm12);
     };
 
 
     struct LdrhStrhImmediateUnsignedOffsetInstruction : LdrbStrbImmediateUnsignedOffsetInstruction
     {
-        LdrhStrhImmediateUnsignedOffsetInstruction(Aarch64Instruction kind, Register Rt, Register Rn, uint16_t imm12);
+        LdrhStrhImmediateUnsignedOffsetInstruction(InstructionKind kind, Register Rt, Register Rn, uint16_t imm12);
     };
 
 
@@ -213,7 +247,7 @@ namespace elet::domain::compiler::test::aarch
         addressMode;
 
         LoadStorePairInstruction(
-            Aarch64Instruction kind,
+            InstructionKind kind,
             Register Rt,
             Register Rt2,
             Register Rn,
@@ -312,7 +346,7 @@ namespace elet::domain::compiler::test::aarch
         Hw
         hw;
 
-        MovInstruction(Aarch64Instruction kind, Register rd, uint16_t imm16, Hw hw, bool is64Bit);
+        MovInstruction(InstructionKind kind, Register rd, uint16_t imm16, Hw hw, bool is64Bit);
     };
 
 
@@ -385,7 +419,7 @@ namespace elet::domain::compiler::test::aarch
         imm6;
 
         ShiftedRegisterInstruction(
-            Aarch64Instruction instruction,
+            InstructionKind instruction,
             Register Rd,
             Register Rn,
             Register Rm,
@@ -421,7 +455,7 @@ namespace elet::domain::compiler::test::aarch
         Register
         Rd;
 
-        MaddSubInstruction(Aarch64Instruction kind, Register Rm, Register Ra, Register Rn, Register Rd, bool is64Bit);
+        MaddSubInstruction(InstructionKind kind, Register Rm, Register Ra, Register Rn, Register Rd, bool is64Bit);
     };
 
 
@@ -436,7 +470,7 @@ namespace elet::domain::compiler::test::aarch
         Register
         Rd;
 
-        DivInstruction(Aarch64Instruction kind, Register Rm, Register Rn, Register Rd, bool is64Bit);
+        DivInstruction(InstructionKind kind, Register Rm, Register Rn, Register Rd, bool is64Bit);
     };
 
 
@@ -448,7 +482,7 @@ namespace elet::domain::compiler::test::aarch
         Register
         Rn;
 
-        SxtbSxtbhInstruction(Aarch64Instruction kind, Register Rd, Register Rn);
+        SxtbSxtbhInstruction(InstructionKind kind, Register Rd, Register Rn);
     };
 
 

--- a/src/Domain/Compiler/TestHarness/Aarch/Aarch64Parser.cpp
+++ b/src/Domain/Compiler/TestHarness/Aarch/Aarch64Parser.cpp
@@ -150,19 +150,19 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseLdrStrImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseLdrStrImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
-        assert(kind == Aarch64Instruction::LdrImmediateUnsignedOffset ||
-            kind == Aarch64Instruction::StrImmediateUnsignedOffset && "Unsupported kind");
+        assert(kind == InstructionKind::LdrImmediateUnsignedOffset ||
+            kind == InstructionKind::StrImmediateUnsignedOffset && "Unsupported kind");
         emplaceInstruction(LdrStrImmediateUnsignedOffsetInstruction(kind, Rt(dw), Rn(dw), imm12(dw), dw & (0b01 << 30)), instructions);
     }
 
 
     void
-    Aarch64Parser::parseLdrbStrbImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseLdrbStrbImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
-        assert(kind == Aarch64Instruction::StrbImmediateUnsignedOffset ||
-            kind == Aarch64Instruction::LdrbImmediateUnsignedOffset && "Must be Strb or Ldrb");
+        assert(kind == InstructionKind::StrbImmediateUnsignedOffset ||
+            kind == InstructionKind::LdrbImmediateUnsignedOffset && "Must be Strb or Ldrb");
         emplaceInstruction(LdrbStrbImmediateUnsignedOffsetInstruction(kind, Rt(dw), Rn(dw), imm12(dw)), instructions);
     }
 
@@ -175,10 +175,10 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseLdrhStrhImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseLdrhStrhImmediateUnsignedOffsetInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
-        assert(kind == Aarch64Instruction::LdrhImmediateUnsignedOffset ||
-            kind == Aarch64Instruction::StrhImmediateUnsignedOffset && "Unsupported kind");
+        assert(kind == InstructionKind::LdrhImmediateUnsignedOffset ||
+            kind == InstructionKind::StrhImmediateUnsignedOffset && "Unsupported kind");
         emplaceInstruction(LdrhStrhImmediateUnsignedOffsetInstruction(kind, Rt(dw), Rn(dw), imm12(dw)), instructions);
     }
 
@@ -191,7 +191,7 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseLoadStorePairInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseLoadStorePairInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
         LoadStorePairInstruction* instruction = emplaceInstruction(LoadStorePairInstruction(
             kind,
@@ -204,16 +204,16 @@ namespace elet::domain::compiler::test::aarch
 
         switch (kind)
         {
-            case Aarch64Instruction::StpPreIndex64:
+            case InstructionKind::StpPreIndex:
                 instruction->is64Bit = true;
                 instruction->addressMode = AddressMode::PreIndex;
                 break;
-            case Aarch64Instruction::StpOffset64:
-            case Aarch64Instruction::LdpOffset64:
+            case InstructionKind::StpOffset:
+            case InstructionKind::LdpOffset:
                 instruction->is64Bit = true;
                 instruction->addressMode = AddressMode::BaseOffset;
                 break;
-            case Aarch64Instruction::LdpPostIndex64:
+            case InstructionKind::LdpPostIndex:
                 instruction->is64Bit = true;
                 instruction->addressMode = AddressMode::PostIndex;
                 break;
@@ -350,9 +350,9 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseMaddSubInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseMaddSubInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
-        assert(kind == Aarch64Instruction::Madd || kind == Aarch64Instruction::Msub && "Unsupported kind");
+        assert(kind == InstructionKind::Madd || kind == InstructionKind::Msub && "Unsupported kind");
         emplaceInstruction(MaddSubInstruction(kind, Rm(dw), Ra(dw), Rn(dw), Rd(dw), sf(dw)), instructions);
     }
 
@@ -394,9 +394,9 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseDivInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseDivInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
-        assert(kind == Aarch64Instruction::Sdiv || kind == Aarch64Instruction::Udiv && "Unsupported kind");
+        assert(kind == InstructionKind::Sdiv || kind == InstructionKind::Udiv && "Unsupported kind");
         emplaceInstruction(DivInstruction(kind, Rm(dw), Rn(dw), Rd(dw), sf(dw)), instructions);
     }
 
@@ -821,7 +821,7 @@ namespace elet::domain::compiler::test::aarch
         switch (opc_V_L)
         {
             case static_cast<uint32_t>(LoadStoreEncoding::Ldp64):
-                parseLoadStorePairInstruction(instructions, dw, Aarch64Instruction::LdpPostIndex64);
+                parseLoadStorePairInstruction(instructions, dw, InstructionKind::LdpPostIndex);
                 return true;
         }
         return false;
@@ -835,10 +835,10 @@ namespace elet::domain::compiler::test::aarch
         switch (opc_V_L)
         {
             case static_cast<uint32_t>(LoadStoreEncoding::Stp64):
-                parseLoadStorePairInstruction(instructions, dw, Aarch64Instruction::StpOffset64);
+                parseLoadStorePairInstruction(instructions, dw, InstructionKind::StpOffset);
                 return true;
             case static_cast<uint32_t>(LoadStoreEncoding::Ldp64):
-                parseLoadStorePairInstruction(instructions, dw, Aarch64Instruction::LdpOffset64);
+                parseLoadStorePairInstruction(instructions, dw, InstructionKind::LdpOffset);
                 return true;
         }
         return false;
@@ -852,7 +852,7 @@ namespace elet::domain::compiler::test::aarch
         switch (opc_V_L)
         {
             case static_cast<uint32_t>(LoadStoreEncoding::Stp64):
-                parseLoadStorePairInstruction(instruction, dw, Aarch64Instruction::StpPreIndex64);
+                parseLoadStorePairInstruction(instruction, dw, InstructionKind::StpPreIndex);
                 return true;
         }
         return false;
@@ -866,16 +866,16 @@ namespace elet::domain::compiler::test::aarch
         switch (sf_op_S)
         {
             case static_cast<uint32_t>(AddSubtract_Immediate_Encoding::Add_Immediate32):
-                parseAddSubtractImmediateInstruction(instructions, dw, Aarch64Instruction::AddImmediate32);
+                parseAddSubtractImmediateInstruction(instructions, dw, InstructionKind::AddImmediate);
                 return true;
             case static_cast<uint32_t>(AddSubtract_Immediate_Encoding::Sub_Immediate32):
-                parseAddSubtractImmediateInstruction(instructions, dw, Aarch64Instruction::SubImmediate32);
+                parseAddSubtractImmediateInstruction(instructions, dw, InstructionKind::SubImmediate);
                 return true;
             case static_cast<uint32_t>(AddSubtract_Immediate_Encoding::Add_Immediate64):
-                parseAddSubtractImmediateInstruction(instructions, dw, Aarch64Instruction::AddImmediate64);
+                parseAddSubtractImmediateInstruction(instructions, dw, InstructionKind::AddImmediate);
                 return true;
             case static_cast<uint32_t>(AddSubtract_Immediate_Encoding::Sub_Immediate64):
-                parseAddSubtractImmediateInstruction(instructions, dw, Aarch64Instruction::SubImmediate64);
+                parseAddSubtractImmediateInstruction(instructions, dw, InstructionKind::SubImmediate);
                 return true;
         }
         return false;
@@ -883,7 +883,7 @@ namespace elet::domain::compiler::test::aarch
 
 
     void
-    Aarch64Parser::parseAddSubtractImmediateInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind)
+    Aarch64Parser::parseAddSubtractImmediateInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind)
     {
         emplaceInstruction(AddSubImmediateInstruction(kind, Rd(dw), Rn(dw), imm12(dw), sf(dw)), instructions);
     }
@@ -896,10 +896,10 @@ namespace elet::domain::compiler::test::aarch
         switch (size_V_opc)
         {
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Strb_Immediate):
-                parseLdrbStrbImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::StrbImmediateUnsignedOffset);
+                parseLdrbStrbImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::StrbImmediateUnsignedOffset);
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Ldrb_Immediate):
-                parseLdrbStrbImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::LdrbImmediateUnsignedOffset );
+                parseLdrbStrbImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::LdrbImmediateUnsignedOffset );
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Ldrsb_Immediate32):
                 parseLdrsbImmediateUnsignedOffsetInstruction(instructions, dw);
@@ -909,17 +909,17 @@ namespace elet::domain::compiler::test::aarch
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Ldr_Immediate_32):
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Ldr_Immediate_64):
-                parseLdrStrImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::LdrImmediateUnsignedOffset);
+                parseLdrStrImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::LdrImmediateUnsignedOffset);
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Str_Immediate_32):
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Str_Immediate_64):
-                parseLdrStrImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::StrImmediateUnsignedOffset);
+                parseLdrStrImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::StrImmediateUnsignedOffset);
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Strh_Immediate):
-                parseLdrhStrhImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::StrhImmediateUnsignedOffset);
+                parseLdrhStrhImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::StrhImmediateUnsignedOffset);
                 return true;
             case static_cast<uint32_t>(LoadStoreRegister_UnsignedImmediate::Ldrh_Immediate):
-                parseLdrhStrhImmediateUnsignedOffsetInstruction(instructions, dw, Aarch64Instruction::LdrhImmediateUnsignedOffset);
+                parseLdrhStrhImmediateUnsignedOffsetInstruction(instructions, dw, InstructionKind::LdrhImmediateUnsignedOffset);
                 return true;
         }
         return false;
@@ -934,11 +934,11 @@ namespace elet::domain::compiler::test::aarch
         {
             case static_cast<uint32_t>(DataProcessing3Source::Madd32):
             case static_cast<uint32_t>(DataProcessing3Source::Madd64):
-                parseMaddSubInstruction(instructions, dw, Aarch64Instruction::Madd);
+                parseMaddSubInstruction(instructions, dw, InstructionKind::Madd);
                 return true;
             case static_cast<uint32_t>(DataProcessing3Source::Msub32):
             case static_cast<uint32_t>(DataProcessing3Source::Msub64):
-                parseMaddSubInstruction(instructions, dw, Aarch64Instruction::Msub);
+                parseMaddSubInstruction(instructions, dw, InstructionKind::Msub);
                 return true;
         }
         return false;
@@ -954,14 +954,14 @@ namespace elet::domain::compiler::test::aarch
             case static_cast<uint32_t>(DataProcessing2Source::opcode_Sdiv):
                 if (S(dw) == 0)
                 {
-                    parseDivInstruction(instructions, dw, Aarch64Instruction::Sdiv);
+                    parseDivInstruction(instructions, dw, InstructionKind::Sdiv);
                     return true;
                 }
                 break;
             case static_cast<uint32_t>(DataProcessing2Source::opcode_Udiv):
                 if (S(dw) == 0)
                 {
-                    parseDivInstruction(instructions, dw, Aarch64Instruction::Udiv);
+                    parseDivInstruction(instructions, dw, InstructionKind::Udiv);
                     return true;
                 }
                 break;

--- a/src/Domain/Compiler/TestHarness/Aarch/Aarch64Parser.h
+++ b/src/Domain/Compiler/TestHarness/Aarch/Aarch64Parser.h
@@ -90,7 +90,7 @@ namespace elet::domain::compiler::test::aarch
         parseMovzInstruction(List<OneOfInstruction>& instructions, uint32_t dw);
 
         void
-        parseLoadStorePairInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseLoadStorePairInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
         parseBInstruction(List<OneOfInstruction>& instructions, uint32_t dw);
@@ -108,7 +108,7 @@ namespace elet::domain::compiler::test::aarch
         parseAdrpInstruction(List<OneOfInstruction>& instruction, uint32_t dw);
 
         void
-        parseAddSubtractImmediateInstruction(List<OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseAddSubtractImmediateInstruction(List<OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
         parseUdfInstruction(List<OneOfInstruction>& instructions, uint32_t dw);
@@ -135,16 +135,16 @@ namespace elet::domain::compiler::test::aarch
         shift(uint32_t dw);
 
         void
-        parseLdrStrImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseLdrStrImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
-        parseLdrbStrbImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseLdrbStrbImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
         parseLdrsbImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw);
 
         void
-        parseLdrhStrhImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseLdrhStrhImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
         parseLdrshImmediateUnsignedOffsetInstruction(List <OneOfInstruction>& instructions, uint32_t dw);
@@ -156,10 +156,10 @@ namespace elet::domain::compiler::test::aarch
         parseSubShiftedRegister(List <OneOfInstruction>& instructions, uint32_t dw);
 
         void
-        parseMaddSubInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseMaddSubInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
-        parseDivInstruction(List <OneOfInstruction>& instructions, uint32_t dw, Aarch64Instruction kind);
+        parseDivInstruction(List <OneOfInstruction>& instructions, uint32_t dw, InstructionKind kind);
 
         void
         parseAndImmediateInstruction(List<OneOfInstruction>& instructions, uint32_t dw);

--- a/src/Domain/Compiler/TestHarness/Aarch/Aarch64Printer.cpp
+++ b/src/Domain/Compiler/TestHarness/Aarch/Aarch64Printer.cpp
@@ -15,95 +15,92 @@ namespace elet::domain::compiler::test::aarch
             _tw.tab();
             switch (instruction->kind)
             {
-                case Aarch64Instruction::AndImmediate:
+                case InstructionKind::AndImmediate:
                     writeAndImmediateInstruction(reinterpret_cast<const AndImmediateInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Adr:
+                case InstructionKind::Adr:
                     writeAdrInstruction(reinterpret_cast<const AdrInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Adrp:
+                case InstructionKind::Adrp:
                     writeAdrpInstruction(reinterpret_cast<const AdrpInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::AddShiftedRegister:
-                case Aarch64Instruction::SubShiftedRegister:
+                case InstructionKind::AddShiftedRegister:
+                case InstructionKind::SubShiftedRegister:
                     writeShiftedRegisterInstruction(reinterpret_cast<const ShiftedRegisterInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Madd:
-                case Aarch64Instruction::Msub:
+                case InstructionKind::Madd:
+                case InstructionKind::Msub:
                     writeMaddSubInstruction(reinterpret_cast<const MaddSubInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Sdiv:
-                case Aarch64Instruction::Udiv:
+                case InstructionKind::Sdiv:
+                case InstructionKind::Udiv:
                     writeDivInstruction(reinterpret_cast<const DivInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Ldr32:
-                case Aarch64Instruction::Ldr64:
+                case InstructionKind::Ldr:
                     writeLdr(reinterpret_cast<const LdrInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::StpPreIndex64:
-                case Aarch64Instruction::StpOffset64:
-                case Aarch64Instruction::LdpPostIndex64:
-                case Aarch64Instruction::LdpOffset64:
+                case InstructionKind::StpPreIndex:
+                case InstructionKind::StpOffset:
+                case InstructionKind::LdpPostIndex:
+                case InstructionKind::LdpOffset:
                     writeLoadStorePairInstruction(reinterpret_cast<const LoadStorePairInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::StrImmediateUnsignedOffset:
-                case Aarch64Instruction::LdrImmediateUnsignedOffset:
-                case Aarch64Instruction::StrImmediateUnsignedOffset64:
-                case Aarch64Instruction::LdrImmediateUnsignedOffset64:
+                case InstructionKind::StrImmediateUnsignedOffset:
+                case InstructionKind::LdrImmediateUnsignedOffset:
                     writeLdrStrImmediateUnsignedOffsetInstruction(reinterpret_cast<const StrUnsignedOffsetInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::LdrbImmediateUnsignedOffset:
-                case Aarch64Instruction::StrbImmediateUnsignedOffset:
+                case InstructionKind::LdrbImmediateUnsignedOffset:
+                case InstructionKind::StrbImmediateUnsignedOffset:
                     writeLdrbStrbImmediateUnsignedOffsetInstruction(reinterpret_cast<const LdrbStrbImmediateUnsignedOffsetInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::LdrhImmediateUnsignedOffset:
-                case Aarch64Instruction::StrhImmediateUnsignedOffset:
+                case InstructionKind::LdrhImmediateUnsignedOffset:
+                case InstructionKind::StrhImmediateUnsignedOffset:
                     writeLdrhStrhImmediateUnsignedOffsetInstruction(reinterpret_cast<const LdrhStrhImmediateUnsignedOffsetInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::LdrsbImmediateUnsignedOffset:
+                case InstructionKind::LdrsbImmediateUnsignedOffset:
                     writeLdrsbImmediateUnsignedOffsetInstruction(reinterpret_cast<const LdrsbImmediateUnsignedOffsetInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::LdrshImmediateUnsignedOffset:
+                case InstructionKind::LdrshImmediateUnsignedOffset:
                     writeLdrshImmediateUnsignedOffsetInstruction(reinterpret_cast<const LdrshImmediateUnsignedOffsetInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::AddImmediate64:
-                case Aarch64Instruction::SubImmediate64:
+                case InstructionKind::AddImmediate:
+                case InstructionKind::SubImmediate:
                     writeDataProcessImmediateInstruction(reinterpret_cast<const DataProcessImmediateInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::OrrImmediate:
+                case InstructionKind::OrrImmediate:
                     writeOrrImmediate(reinterpret_cast<const OrrImmediateInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Movz:
+                case InstructionKind::Movz:
                     writeMovz(reinterpret_cast<const MovzInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Movn:
+                case InstructionKind::Movn:
                     writeMovn(reinterpret_cast<const MovnInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Movk:
+                case InstructionKind::Movk:
                     writeMovk(reinterpret_cast<const MovkInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Sxtb:
+                case InstructionKind::Sxtb:
                     writeSxtb(reinterpret_cast<const SxtbInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Sxth:
+                case InstructionKind::Sxth:
                     writeSxth(reinterpret_cast<const SxthInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::B:
+                case InstructionKind::B:
                     writeB(reinterpret_cast<const BInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Bl:
+                case InstructionKind::Bl:
                     writeBl(reinterpret_cast<const BlInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Br:
+                case InstructionKind::Br:
                     writeBr(reinterpret_cast<const BrInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Ret:
+                case InstructionKind::Ret:
                     writeBranchExceptionSyscallInstruction(reinterpret_cast<const BrInstruction*>(instruction));
                     break;
-                case Aarch64Instruction::Nop:
+                case InstructionKind::Nop:
                     writeNopInstruction();
                     break;
-                case Aarch64Instruction::Udf:
+                case InstructionKind::Udf:
                     writeUdf(reinterpret_cast<const UdfInstruction*>(instruction));
                     break;
                 default:
@@ -154,7 +151,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeLdrStrImmediateUnsignedOffsetInstruction(const LdrStrImmediateUnsignedOffsetInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::LdrImmediateUnsignedOffset || instruction->kind == Aarch64Instruction::LdrImmediateUnsignedOffset64)
+        if (instruction->kind == InstructionKind::LdrImmediateUnsignedOffset)
         {
             _tw.write("ldr ");
         }
@@ -181,7 +178,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeLdrbStrbImmediateUnsignedOffsetInstruction(const LdrbStrbImmediateUnsignedOffsetInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::LdrbImmediateUnsignedOffset)
+        if (instruction->kind == InstructionKind::LdrbImmediateUnsignedOffset)
         {
             _tw.write("ldrb ");
         }
@@ -214,7 +211,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeLdrhStrhImmediateUnsignedOffsetInstruction(const LdrhStrhImmediateUnsignedOffsetInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::LdrhImmediateUnsignedOffset)
+        if (instruction->kind == InstructionKind::LdrhImmediateUnsignedOffset)
         {
             _tw.write("ldrh ");
         }
@@ -276,12 +273,12 @@ namespace elet::domain::compiler::test::aarch
     {
         switch (instruction->kind)
         {
-            case Aarch64Instruction::LdpOffset64:
-            case Aarch64Instruction::LdpPostIndex64:
+            case InstructionKind::LdpOffset:
+            case InstructionKind::LdpPostIndex:
                 _tw.write("ldp ");
                 break;
-            case Aarch64Instruction::StpPreIndex64:
-            case Aarch64Instruction::StpOffset64:
+            case InstructionKind::StpPreIndex:
+            case InstructionKind::StpOffset:
                 _tw.write("stp ");
                 break;
             default:
@@ -383,7 +380,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeBranchExceptionSyscallInstruction(const BrInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::Ret)
+        if (instruction->kind == InstructionKind::Ret)
         {
             _tw.write("ret ");
             writeGeneralPurposeRegister(instruction->Rn, instruction);
@@ -420,10 +417,10 @@ namespace elet::domain::compiler::test::aarch
     {
         switch (instruction->kind)
         {
-            case Aarch64Instruction::AddImmediate64:
+            case InstructionKind::AddImmediate:
                 _tw.write("add ");
                 break;
-            case Aarch64Instruction::SubImmediate64:
+            case InstructionKind::SubImmediate:
                 _tw.write("sub ");
                 break;
             default:
@@ -559,7 +556,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeShiftedRegisterInstruction(const ShiftedRegisterInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::AddShiftedRegister)
+        if (instruction->kind == InstructionKind::AddShiftedRegister)
         {
             _tw.write("add ");
         }
@@ -583,7 +580,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeMaddSubInstruction(const MaddSubInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::Madd)
+        if (instruction->kind == InstructionKind::Madd)
         {
             if (instruction->Ra == Register::Zero)
             {
@@ -620,7 +617,7 @@ namespace elet::domain::compiler::test::aarch
     void
     Aarch64Printer::writeDivInstruction(const DivInstruction* instruction)
     {
-        if (instruction->kind == Aarch64Instruction::Sdiv)
+        if (instruction->kind == InstructionKind::Sdiv)
         {
             _tw.write("sdiv ");
         }


### PR DESCRIPTION
Fixes #12 